### PR TITLE
Retrieval of data types in ARGetMultipleFields()

### DIFF
--- a/pyremedy/ars.py
+++ b/pyremedy/ars.py
@@ -275,7 +275,7 @@ class ARS(object):
         missing = set(self.field_name_to_id_cache[schema]).difference(fields)
         if missing:
             raise ARSError(
-				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
+				'Schema {} does not have field(s): {}'.format(schema, ', '.join(sorted(missing)))
 			)
 
         entry_id_list = arh.AREntryIdList()
@@ -391,7 +391,7 @@ class ARS(object):
         missing = set(self.field_name_to_id_cache[schema]).difference(fields)
         if missing:
             raise ARSError(
-				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
+				'Schema {} does not have field(s): {}'.format(schema, ', '.join(sorted(missing)))
 			)
 
         schema_artype = arh.ARNameType()
@@ -590,7 +590,7 @@ class ARS(object):
         missing = set(self.field_name_to_id_cache[schema]).difference(entry_values.keys())
         if missing:
             raise ARSError(
-				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
+				'Schema {} does not have field(s): {}'.format(schema, ', '.join(sorted(missing)))
 			)
 
         # Prepare the fields that will be added to the new entry
@@ -668,7 +668,7 @@ class ARS(object):
         missing = set(self.field_name_to_id_cache[schema]).difference(entry_values.keys())
         if missing:
             raise ARSError(
-				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
+				'Schema {} does not have field(s): {}'.format(schema, ', '.join(sorted(missing)))
 			)
 
         # Prepare the entry id struct

--- a/pyremedy/ars.py
+++ b/pyremedy/ars.py
@@ -838,6 +838,7 @@ class ARS(object):
         field_name_list = arh.ARNameList()
         field_exist_list = arh.ARBooleanList()
         field_limits_list = arh.ARFieldLimitList()
+        field_type_list = arh.ARUnsignedIntList()
 
         if (
             self.arlib.ARGetMultipleFields(
@@ -860,7 +861,7 @@ class ARS(object):
                 # underlying form which to retrieve fields
                 None,
                 # (return) ARUnsignedIntList *dataType: field data types
-                None,
+                byref(field_type_list),
                 # (return) ARUnsignedIntList *option: flags indicating whether
                 # users must enter values in the form
                 None,
@@ -925,7 +926,7 @@ class ARS(object):
             # Save the field name to id mapping in the cache
             field_id = field_id_list.internalIdList[i]
             field_name = field_name_list.nameList[i].value
-            data_type = field_limits_list.fieldLimitList[i].dataType
+            data_type = field_type_list.intList[i]
 
             # Save the field id to name mapping in the cache
             self.field_id_to_name_cache[schema][field_id] = field_name

--- a/pyremedy/ars.py
+++ b/pyremedy/ars.py
@@ -277,12 +277,6 @@ class ARS(object):
             raise ARSError(
 				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
 			)
-        #for field in fields:
-        #    if field not in self.field_name_to_id_cache[schema]:
-        #        raise ARSError(
-        #            'A field with name {} does not exist in schema '
-        #            '{}'.format(field, schema)
-        #        )
 
         entry_id_list = arh.AREntryIdList()
         entry_id_list.numItems = 1
@@ -399,12 +393,6 @@ class ARS(object):
             raise ARSError(
 				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
 			)
-        #for field in fields:
-        #    if field not in self.field_name_to_id_cache[schema]:
-        #        raise ARSError(
-        #            'A field with name {} does not exist in schema '
-        #            '{}'.format(field, schema)
-        #        )
 
         schema_artype = arh.ARNameType()
         schema_artype.value = schema
@@ -604,12 +592,6 @@ class ARS(object):
             raise ARSError(
 				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
 			)
-        #for field in entry_values.keys():
-        #    if field not in self.field_name_to_id_cache[schema]:
-        #        raise ARSError(
-        #            'A field with name {} does not exist in schema '
-        #            '{}'.format(field, schema)
-        #        )
 
         # Prepare the fields that will be added to the new entry
         field_value_list = arh.ARFieldValueList()
@@ -688,12 +670,6 @@ class ARS(object):
             raise ARSError(
 				'Schema {} does not have field(s): {}'.format(schema, ', '.join(missing))
 			)
-        #for field in entry_values.keys():
-        #    if field not in self.field_name_to_id_cache[schema]:
-        #        raise ARSError(
-        #            'A field with name {} does not exist in schema '
-        #            '{}'.format(field, schema)
-        #        )
 
         # Prepare the entry id struct
         entry_id_list = arh.AREntryIdList()

--- a/pyremedy/ars.py
+++ b/pyremedy/ars.py
@@ -1264,7 +1264,7 @@ class ARS(object):
                 )
             field_value_struct.value.u.enumVal = enum_id
         elif data_type == arh.AR_DATA_TYPE_TIME:
-            field_value_struct.value.u.timeVal = value.strftime('%s')
+            field_value_struct.value.u.timeVal = int(value.strftime('%s'))
         else:
             raise ARSError(
                 'An unknown data type was encountered for field name {} '


### PR DESCRIPTION
Changed to use the 'dataType' argument instead of the 'limit' argument.

This fixes (for me) issue with AR_DATA_TYPE_TIME fields type getting incorrect type AR_DATA_TYPE_NULL.
